### PR TITLE
Changed passing badge to PR.yaml

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: Pull request
+name: Tests on pull request
 on:
   pull_request:
     branches: [main]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CGO cataloged](https://img.shields.io/badge/CGO-catalogued-9cf)](https://github.com/TheCGO)
 [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-3916/)
-![example event parameter](https://github.com/TheCGO/fiscalsim-us/actions/workflows/push.yaml/badge.svg?branch=main)
+![example event parameter](https://github.com/TheCGO/fiscalsim-us/actions/workflows/pr.yaml/badge.svg?branch=main)
 [![Codecov](https://codecov.io/gh/TheCGO/fiscalsim-us/branch/main/graph/badge.svg)](https://codecov.io/gh/TheCGO/fiscalsim-us)
 
 FiscalSim US is a microsimulation model of the US state and federal household tax and benefit system. It is supported and maintained by [The Center for Growth and Opportunity at Utah State University](https://www.thecgo.org/). Much of the original federal tax and benefit code and some of the state tax logic was developed by [PolicyEngine](https://policyengine.org/), with their US model at [https://github.com/PolicyEngine/policyengine-us](https://github.com/PolicyEngine/policyengine-us).


### PR DESCRIPTION
This PR changes the test passing badge in the `README.md` file to read the status of the `pr.yaml` GitHub Action. For some reason, the `push.yaml` GA was always reading "failing" in the badge even if all the tests were passing.