### PR TITLE
Fix push.yaml

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Test documentation builds
         if: matrix.os == 'ubuntu-latest'
         run: make documentation
-Publish:
+  Publish:
     runs-on: ubuntu-latest
     if: |
       (github.repository == 'TheCGO/fiscalsim-us')


### PR DESCRIPTION
This PR fixes an indent error in the `push.yaml` GitHub Action file. This should have been done in PR #40.