### PR TITLE
Corrected Kansas SD for WIDOW filing status

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Updated the value for the Kansas standard deduction amount for Widow filer types.

--- a/fiscalsim_us/parameters/gov/states/ks/tax/income/deductions/standard/base_amount.yaml
+++ b/fiscalsim_us/parameters/gov/states/ks/tax/income/deductions/standard/base_amount.yaml
@@ -20,9 +20,9 @@ HEAD_OF_HOUSEHOLD:
   2013-01-01: 5_500
   2021-01-01: 6_000
 WIDOW:
-  #The K-40 instructions on page 6 read as follows:
-  #If your federal filing status is Qualifying Widow(er) with
-  #Dependent Child, check the Head of Household box.
+  # The K-40 instructions on page 6 read as follows:
+  # If your federal filing status is Qualifying Widow(er) with
+  # Dependent Child, check the Head of Household box.
   2013-01-01: 5_500
   2021-01-01: 6_000
 SINGLE:

--- a/fiscalsim_us/parameters/gov/states/ks/tax/income/deductions/standard/base_amount.yaml
+++ b/fiscalsim_us/parameters/gov/states/ks/tax/income/deductions/standard/base_amount.yaml
@@ -20,8 +20,11 @@ HEAD_OF_HOUSEHOLD:
   2013-01-01: 5_500
   2021-01-01: 6_000
 WIDOW:
-  2013-01-01: 7_500
-  2021-01-01: 8_000
+  #The K-40 instructions on page 6 read as follows:
+  #If your federal filing status is Qualifying Widow(er) with
+  #Dependent Child, check the Head of Household box.
+  2013-01-01: 5_500
+  2021-01-01: 6_000
 SINGLE:
   2013-01-01: 3_000
   2021-01-01: 3_500


### PR DESCRIPTION
Changed the standard deduction amount for WIDOW filing status for Kansas. It was previously the same as JOINT, when it should have been the same as HEAD_OF_HOUSEHOLD.