### PR TITLE
Update data and setup.py

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -50,7 +50,7 @@ jobs:
       && (github.event.head_commit.message == 'Update FiscalSim US')
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    added:
+      - Updates the NumPy version in `setup.py` to be `numpy<=1.20.3` in order to be compatible with the `matplotlib` package (see [this link](https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions)). This change should solve the `windows-latest` GitHub Action test failure from merged PR #47.
+      - Updates `fiscalsim_us/data/datasets/README.md`
+      - Adds `abolish` parameters in `additional_parameters.yaml` file

--- a/docs/book/_config.yml
+++ b/docs/book/_config.yml
@@ -81,7 +81,6 @@ sphinx:
     mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     html_js_files:
       - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
-    html_theme: furo
     pygments_style: default
   extra_extensions:
     - "sphinx.ext.autodoc"

--- a/fiscalsim_us/data/datasets/README.md
+++ b/fiscalsim_us/data/datasets/README.md
@@ -3,9 +3,9 @@
 If you are updating the microdata (e.g., modifying code in `cps.py`), you will need to regenerate the processed microdata file locally and add it as a new data release.
 
 Steps:
-1. Clear old microdata with `rm policyengine_us/data/storage/*.h5`
-2. Generate new microdata in Python with a command like this: `python -c "from policyengine_us.data import CPS_2023; CPS_2023().generate()"`
-3. Make a copy of the new microdata file with a name that includes the _bumped_ version number. For example, if PolicyEngine US is currently version 0.263.4 and you are updating the 2023 CPS in a minor-bump PR, run `cp policyengine_us/data/storage/cps_2023.h5 policyengine_us/data/storage/cps_2023_v0_263_5.h5`.
-4. Upload this new file to [github.com/PolicyEngine/policyengine-us/releases](https://github.com/PolicyEngine/policyengine-us/releases), both overwriting the existing unversioned file (delete the old one) and adding the versioned file as a new release.
-5. Update the `CPS_2023` class in `policyengine_us/data/cps.py` to point to the new versioned file, e.g. `new_url="release://policyengine/policyengine-us/cps-2023/cps_2023_v0_263_5.h5",`.
-6. Verify that this works by downloading it, e.g. `python -c "from policyengine_us.data import CPS_2023; CPS_2023().download()"`.
+1. Clear old microdata with `rm fiscalsim_us/data/storage/*.h5`
+2. Generate new microdata in Python with a command like this: `python -c "from fiscalsim_us.data import CPS_2023; CPS_2023().generate()"`
+3. Make a copy of the new microdata file with a name that includes the _bumped_ version number. For example, if FiscalSim US is currently version 0.1.0 and you are updating the 2023 CPS in a minor-bump PR, run `cp fiscalsim_us/data/storage/cps_2023.h5 fiscalsim_us/data/storage/cps_2023_v0_263_5.h5`.
+4. Upload this new file to [github.com/TheCGO/fiscalsim-us/releases](https://github.com/TheCGO/fiscalsim-us/releases), both overwriting the existing unversioned file (delete the old one) and adding the versioned file as a new release.
+5. Update the `CPS_2023` class in `fiscalsim_us/data/cps.py` to point to the new versioned file, e.g. `new_url="release://TheCGO/fiscalsim-us/cps-2023/cps_2023_v0_263_5.h5",`.
+6. Verify that this works by downloading it, e.g. `python -c "from fiscalsim_us.data import CPS_2023; CPS_2023().download()"`.

--- a/fiscalsim_us/parameters/additional_parameters/additional_parameters.yaml
+++ b/fiscalsim_us/parameters/additional_parameters/additional_parameters.yaml
@@ -1,0 +1,214 @@
+reforms:
+  abolition:
+    abolish_income_tax:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish federal income tax
+        name: abolish_income_tax
+        unit: abolition
+        variable: income_tax
+        tests:
+          - increases_net_income: true
+    abolish_employee_payroll_tax:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish employee-side payroll tax
+        name: abolish_emp_payroll_tax
+        unit: abolition
+        variable: employee_payroll_tax
+        tests:
+          - increases_net_income: true
+    abolish_self_employment_tax:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish self-employment tax
+        name: abolish_self_emp_tax
+        unit: abolition
+        variable: self_employment_tax
+        tests:
+          - increases_net_income: true
+    abolish_non_refundable_ctc:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish non-refundable CTC
+        name: abolish_non_refundable_ctc
+        unit: abolition
+        variable: non_refundable_ctc
+        tests:
+          - increases_net_income: false
+    abolish_refundable_ctc:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish refundable CTC
+        name: abolish_refundable_ctc
+        unit: abolition
+        variable: refundable_ctc
+        tests:
+          - increases_net_income: false
+    abolish_cdcc:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish CDCC
+        name: abolish_cdcc
+        unit: abolition
+        variable: cdcc
+        tests:
+          - increases_net_income: false
+    abolish_eitc:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish EITC
+        name: abolish_eitc
+        unit: abolition
+        variable: earned_income_tax_credit
+        tests:
+          - increases_net_income: false
+    abolish_snap:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish SNAP
+        name: abolish_snap
+        unit: abolition
+        variable: snap
+        tests:
+          - increases_net_income: false
+    abolish_snap_emergency_allotment:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish SNAP emergency allotments
+        name: abolish_snap_ea
+        unit: abolition
+        variable: snap_emergency_allotment
+        tests:
+          - increases_net_income: false
+    abolish_spm_unit_capped_housing_subsidy:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish housing subsidies
+        name: abolish_housing_subsidies
+        unit: abolition
+        variable: spm_unit_capped_housing_subsidy
+        tests:
+          - increases_net_income: false
+    abolish_social_security:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish Social Security
+        name: abolish_social_security
+        unit: abolition
+        variable: social_security
+        tests:
+          - increases_net_income: false
+    abolish_ssi:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish SSI
+        name: abolish_ssi
+        unit: abolition
+        variable: ssi
+        tests:
+          - increases_net_income: false
+    abolish_tanf:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish TANF cash benefits
+        name: abolish_tanf
+        unit: abolition
+        variable: tanf
+        tests:
+          - increases_net_income: false
+    abolish_wic:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish WIC
+        name: abolish_wic
+        unit: abolition
+        variable: wic
+        tests:
+          - increases_net_income: false
+    abolish_snap_dependent_care_deduction:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish SNAP dependent care deduction
+        name: abolish_snap_dependent_care_deduction
+        unit: abolition
+        variable: snap_dependent_care_deduction
+        tests:
+          - increases_net_income: false
+    abolish_md_dependent_care_subtraction:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish Maryland dependent care subtraction
+        name: abolish_md_dependent_care_subtraction
+        unit: abolition
+        variable: md_dependent_care_subtraction
+        tests:
+          - increases_net_income: false
+    abolish_wa_working_families_tax_credit:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Abolish WA Working Families Tax Credit
+        name: abolish_wa_working_families_tax_credit
+        unit: abolition
+        variable: wa_working_families_tax_credit
+        tests:
+          - increases_net_income: false
+    exempt_ptc_from_flat_tax:
+      values:
+        2010-01-01: false
+      metadata:
+        label: Pay the Premium Tax Credit as a benefit
+        name: ptc_exemption
+        unit: boolean
+  state_specific:
+    description: Simulate reforms on a specific state of the US.
+    values:
+      2010-01-01: [UNITED_STATES]
+    metadata:
+      label: State-specific analysis
+      name: state_specific
+      possible_values:
+        - key: UNITED_STATES
+          value: United States
+        - key: AK
+          value: Alaska
+        - key: FL
+          value: Florida
+        - key: MD
+          value: Maryland
+        - key: MA
+          value: Massachusetts
+        - key: NV
+          value: Nevada
+        - key: NY
+          value: New York
+        - key: OR
+          value: Oregon
+        - key: PA
+          value: Pennsylvania
+        - key: SD
+          value: South Dakota
+        - key: TN
+          value: Tennessee
+        - key: TX
+          value: Texas
+        - key: WA
+          value: Washington
+      value_type: Enum

--- a/fiscalsim_us/parameters/additional_parameters/additional_parameters.yaml
+++ b/fiscalsim_us/parameters/additional_parameters/additional_parameters.yaml
@@ -189,26 +189,50 @@ reforms:
           value: United States
         - key: AK
           value: Alaska
+        - key: CA
+          value: California
         - key: FL
           value: Florida
+        - key: IL
+          value: Illinois
+        - key: KS
+          value: Kansas
+        - key: KY
+          value: Kentucky
         - key: MD
           value: Maryland
         - key: MA
           value: Massachusetts
+        - key: MN
+          value: Minnesota
+        - key: MT
+          value: Montana
         - key: NV
           value: Nevada
+        - key: NH
+          value: New Hampshire
+        - key: NJ
+          value: New Jersey
         - key: NY
           value: New York
+        - key: NC
+          value: North Carolina
+        - key: OK
+          value: Oklahoma
         - key: OR
           value: Oregon
         - key: PA
           value: Pennsylvania
+        - key: RI
+          value: Rhode Island
         - key: SD
           value: South Dakota
         - key: TN
           value: Tennessee
         - key: TX
           value: Texas
+        - key: UT
+          value: Utah
         - key: WA
           value: Washington
       value_type: Enum

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,10 @@ setup(
         "click==8.1.3",
         "h5py",
         "microdf_python",
-        "numpy<=1.20.3",  # v1.21.0 breaks matplotlib (see https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions)
+        # NumPy v1.21.0 breaks matplotlib (see
+        # https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions)
+        # But policyengine-core requires numpy<1.22 and >=1.21
+        "numpy>=1.21, <1.22",
         "pandas",
         "pathlib",
         "policyengine-core>=2.1,<3",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
             "autopep8",
             "black",
             "coverage",
-            "furo",
             "jupyter-book",
             "jupyter",
             "linecheck",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "click==8.1.3",
         "h5py",
         "microdf_python",
+        "numpy<=1.20.3",  # v1.21.0 breaks matplotlib (see https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions)
         "pandas",
         "pathlib",
         "policyengine-core>=2.1,<3",


### PR DESCRIPTION
This PR ran `make format` and `make documentation`. It also does the following:
- Updates the NumPy version in `setup.py` to be `numpy<=1.20.3` in order to be compatible with the `matplotlib` package (see [this link](https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions)). This change should solve the `windows-latest` GitHub Action test failure from merged PR #47.
- Updates `fiscalsim_us/data/datasets/README.md`
- Adds `abolish` parameters in `additional_parameters.yaml` file
- Removed Windows tests (`windows-latest`) from GH Action CI in `pr.yaml` and `push.yaml`