### PR TITLE
Update to Python 3.10, NumPy, and PolicyEngine-core

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install package
         run: make install
       - name: Run tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build and test [Python 3.9]
+name: Build and test [Python 3.10]
 on: [push, pull_request]
 jobs:
   build:
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
 
     steps:
       - name: Checkout
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install package
         run: make install
       - name: Run tests

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -18,7 +18,7 @@ jobs:
           miniforge-variant: Mambaforge
           activate-environment: fiscalsim-us-dev
           environment-file: environment.yml
-          python-version: "3.9"
+          python-version: "3.10"
           auto-activate-base: false
       - name: Install package and build documentation
         shell: bash -l {0}

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -15,7 +15,7 @@ jobs:
           miniforge-variant: Mambaforge
           activate-environment: fiscalsim-us-dev
           environment-file: environment.yml
-          python-version: "3.9"
+          python-version: "3.10"
           auto-activate-base: false
       - name: Install package and build documentation
         shell: bash -l {0}

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Build package
         run: make pip-package
       - name: Publish a Python distribution to PyPI

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Build package
         run: make pip-package
       - name: Publish a Python distribution to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-10-09 02:00:00
+
+### Added
+
+- Updates the Python version to 3.10 in `environment.yml`, `setup.py`, `README.md`, `build_and_test.yml`, `deploy_docs.yml`, `docs_check.yml`, and `publish_to_pypi.yml`.
+- Adds back the Windows CI tests to `build_and_test.yml. See Issue #49.
+-  Updates to `numpy>=1.24,<1.24` and `policyengine-core>=2.8,<3` in `setup.py`. This change is what enabled the update to Python 3.10 and came from [PR #117](https://github.com/PolicyEngine/policyengine-core/pull/117) to `policyengine-core`.
+
 ## [0.1.5] - 2023-09-20 17:00:00
 
 ### Added
@@ -144,7 +152,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First prototype version based off of openfisca-us and tax-calculator.
 
 
-
+[0.2.0]: https://github.com/TheCGO/fiscalsim-us/compare/0.1.5...0.2.0
+[0.1.5]: https://github.com/TheCGO/fiscalsim-us/compare/0.1.4...0.1.5
+[0.1.4]: https://github.com/TheCGO/fiscalsim-us/compare/0.1.3...0.1.4
+[0.1.3]: https://github.com/TheCGO/fiscalsim-us/compare/0.1.2...0.1.3
 [0.1.2]: https://github.com/TheCGO/fiscalsim-us/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/TheCGO/fiscalsim-us/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/TheCGO/fiscalsim-us/compare/0.0.12...0.1.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | | |
 | --- | --- |
 | Org | [![CGO cataloged](https://img.shields.io/badge/CGO-catalogued-9cf)](https://github.com/TheCGO) [![OS License: AGPL-3.0](https://img.shields.io/badge/OS%20License-AGPL%203.0-yellow)](https://github.com/TheCGO/fiscalsim-us/blob/main/LICENSE) |
-| Package | [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-3916/) [![PyPI Latest Release](https://img.shields.io/pypi/v/fiscalsim-us.svg)](https://pypi.org/project/fiscalsim-us/) [![PyPI Downloads](https://img.shields.io/pypi/dm/fiscalsim-us.svg?label=PyPI%20downloads)](https://pypi.org/project/fiscalsim-us/) |
+| Package | [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-31013/) [![PyPI Latest Release](https://img.shields.io/pypi/v/fiscalsim-us.svg)](https://pypi.org/project/fiscalsim-us/) [![PyPI Downloads](https://img.shields.io/pypi/dm/fiscalsim-us.svg?label=PyPI%20downloads)](https://pypi.org/project/fiscalsim-us/) |
 | Testing | ![example event parameter](https://github.com/TheCGO/fiscalsim-us/actions/workflows/build_and_test.yml/badge.svg?branch=main) ![example event parameter](https://github.com/TheCGO/fiscalsim-us/actions/workflows/deploy_docs.yml/badge.svg?branch=main) ![example event parameter](https://github.com/TheCGO/fiscalsim-us/actions/workflows/check_format.yml/badge.svg?branch=main) [![Codecov](https://codecov.io/gh/TheCGO/fiscalsim-us/branch/main/graph/badge.svg)](https://codecov.io/gh/TheCGO/fiscalsim-us) |
 
 

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -134,3 +134,8 @@
     added:
       - Updated `README.md` and its badges.
   date: 2023-09-20 17:00:00
+- bump: minor
+  changes:
+    added:
+      - Updated `README.md` and its badges.
+  date: 2023-10-09 02:00:00

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
 name: fiscalsim-us-dev
 dependencies:
-  - python=3.9
+  - python=3.10
   - pip

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="fiscalsim-us",
-    version="0.1.5",
+    version="0.2.0",
     author="Center for Growth and Opportunity at Utah State University (CGO)",
     author_email="fiscalsim@thecgo.org",
     long_description=readme,
@@ -17,7 +17,7 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: POSIX",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     description="FiscalSim federal and state individual tax and benefit system for the US",
@@ -38,10 +38,10 @@ setup(
         # NumPy v1.21.0 breaks matplotlib (see
         # https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions)
         # But policyengine-core requires numpy<1.22 and >=1.21
-        "numpy>=1.21, <1.22",
+        "numpy>=1.24, <1.25",
         "pandas",
         "pathlib",
-        "policyengine-core>=2.1,<3",
+        "policyengine-core>=2.8,<3",
         "pytest",
         "pytest-dependency",
         "pyyaml",
@@ -73,7 +73,7 @@ setup(
         ],
     },
     # Windows CI requires Python 3.9.
-    python_requires=">=3.7, <3.10",
+    python_requires=">=3.10, <3.12",
     entry_points={
         "console_scripts": [
             "fiscalsim-us = fiscalsim_us.tools.cli:main",


### PR DESCRIPTION
- [x] `make format` and `make documentation` has been run. (You may also want to run `make test`.)

This PR:
- Updates the Python version to 3.10 in `environment.yml`, `setup.py`, `README.md`, `build_and_test.yml`, `deploy_docs.yml`, `docs_check.yml`, and `publish_to_pypi.yml`. 
- Adds back the Windows CI tests to `build_and_test.yml. See Issue #49.
-  Updates to `numpy>=1.24,<1.24` and `policyengine-core>=2.8,<3` in `setup.py`. This change is what enabled the update to Python 3.10 and came from [PR #117](https://github.com/PolicyEngine/policyengine-core/pull/117) to `policyengine-core`.