### PR TITLE
Fix min_ references in two variable files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Updated two files `la_nonrefundable_childcare.py` and `in_unemployment_compensation_deduction.py` that need a `min()` reference updated to `min_()`
+- Updates two files `la_nonrefundable_childcare.py` and `in_unemployment_compensation_deduction.py` that need a `min()` reference updated to `min_()`
 
 ## [0.2.0] - 2023-10-09 01:30:00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2023-10-09 02:00:00
+## [0.2.1] - 2023-10-09 02:00:00
+
+### Added
+
+- Updated two files `la_nonrefundable_childcare.py` and `in_unemployment_compensation_deduction.py` that need a `min()` reference updated to `min_()`
+
+## [0.2.0] - 2023-10-09 01:30:00
 
 ### Added
 
 - Updates the Python version to 3.10 in `environment.yml`, `setup.py`, `README.md`, `build_and_test.yml`, `deploy_docs.yml`, `docs_check.yml`, and `publish_to_pypi.yml`.
-- Adds back the Windows CI tests to `build_and_test.yml. See Issue #49.
--  Updates to `numpy>=1.24,<1.24` and `policyengine-core>=2.8,<3` in `setup.py`. This change is what enabled the update to Python 3.10 and came from [PR #117](https://github.com/PolicyEngine/policyengine-core/pull/117) to `policyengine-core`.
+- Adds back the Windows CI tests to `build_and_test.yml`. See Issue #49.
+- Updates to `numpy>=1.24,<1.24` and `policyengine-core>=2.8,<3` in `setup.py`. This change is what enabled the update to Python 3.10 and came from [PR #117](https://github.com/PolicyEngine/policyengine-core/pull/117) to `policyengine-core`.
 
 ## [0.1.5] - 2023-09-20 17:00:00
 
@@ -152,6 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First prototype version based off of openfisca-us and tax-calculator.
 
 
+[0.2.1]: https://github.com/TheCGO/fiscalsim-us/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/TheCGO/fiscalsim-us/compare/0.1.5...0.2.0
 [0.1.5]: https://github.com/TheCGO/fiscalsim-us/compare/0.1.4...0.1.5
 [0.1.4]: https://github.com/TheCGO/fiscalsim-us/compare/0.1.3...0.1.4

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -144,5 +144,5 @@
 - bump: patch
   changes:
     added:
-      - Updated two files `la_nonrefundable_childcare.py` and `in_unemployment_compensation_deduction.py` that need a `min()` reference updated to `min_()`
+      - Updates two files `la_nonrefundable_childcare.py` and `in_unemployment_compensation_deduction.py` that need a `min()` reference updated to `min_()`
   date: 2023-10-09 02:00:00

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -137,5 +137,12 @@
 - bump: minor
   changes:
     added:
-      - Updated `README.md` and its badges.
+      - Updates the Python version to 3.10 in `environment.yml`, `setup.py`, `README.md`, `build_and_test.yml`, `deploy_docs.yml`, `docs_check.yml`, and `publish_to_pypi.yml`.
+      - Adds back the Windows CI tests to `build_and_test.yml`. See Issue 49.
+      - Updates to `numpy>=1.24,<1.24` and `policyengine-core>=2.8,<3` in `setup.py`. This change is what enabled the update to Python 3.10 and came from PR 117 to `policyengine-core`.
+  date: 2023-10-09 01:30:00
+- bump: patch
+  changes:
+    added:
+      - Updated two files `la_nonrefundable_childcare.py` and `in_unemployment_compensation_deduction.py` that need a `min()` reference updated to `min_()`
   date: 2023-10-09 02:00:00

--- a/fiscalsim_us/variables/gov/states/in/tax/income/deductions/in_unemployment_compensation_deduction.py
+++ b/fiscalsim_us/variables/gov/states/in/tax/income/deductions/in_unemployment_compensation_deduction.py
@@ -25,7 +25,7 @@ class in_unemployment_compensation_deduction(Variable):
         reduced_agi_haircut = p.unemployment_compensation.reduced_agi_haircut
         in_taxable_unemployment_compensation = min_(
             (reduced_agi_haircut * reduced_agi),
-            unemployment_compensation_in_federal_agi
+            unemployment_compensation_in_federal_agi,
         )
         return (
             unemployment_compensation_in_federal_agi

--- a/fiscalsim_us/variables/gov/states/in/tax/income/deductions/in_unemployment_compensation_deduction.py
+++ b/fiscalsim_us/variables/gov/states/in/tax/income/deductions/in_unemployment_compensation_deduction.py
@@ -23,9 +23,9 @@ class in_unemployment_compensation_deduction(Variable):
         ]
         reduced_agi = max(0, federal_agi - agi_reduction)
         reduced_agi_haircut = p.unemployment_compensation.reduced_agi_haircut
-        in_taxable_unemployment_compensation = min(
+        in_taxable_unemployment_compensation = min_(
             (reduced_agi_haircut * reduced_agi),
-            unemployment_compensation_in_federal_agi,
+            unemployment_compensation_in_federal_agi
         )
         return (
             unemployment_compensation_in_federal_agi

--- a/fiscalsim_us/variables/gov/states/la/tax/income/credits/la_nonrefundable_childcare.py
+++ b/fiscalsim_us/variables/gov/states/la/tax/income/credits/la_nonrefundable_childcare.py
@@ -31,6 +31,6 @@ class la_nonrefundable_childcare(Variable):
         # fed_cdcc * income_mult and the limit for above the threshold
         return where(
             agi > p.income_threshold,
-            min(credit, p.above_threshold_max),
+            min_(credit, p.above_threshold_max),
             credit,
         )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="fiscalsim-us",
-    version="0.2.0",
+    version="0.2.1",
     author="Center for Growth and Opportunity at Utah State University (CGO)",
     author_email="fiscalsim@thecgo.org",
     long_description=readme,


### PR DESCRIPTION
- [x] `make format` and `make documentation` has been run. (You may also want to run `make test`.)

This PR:
- Updates two files `la_nonrefundable_childcare.py` and `in_unemployment_compensation_deduction.py` that need a `min()` reference updated to `min_()`

cc: @mitchellpound 