### PR TITLE
Added la_agi_subtractions tests back

### DIFF
--- a/fiscalsim_us/tests/policy/baseline/gov/states/la/tax/income/la_agi_subtractions.yaml
+++ b/fiscalsim_us/tests/policy/baseline/gov/states/la/tax/income/la_agi_subtractions.yaml
@@ -1,0 +1,16 @@
+- name: LA subtractions from income
+  period: 2021
+  absolute_error_margin: 0
+  input:
+    filing_status: SINGLE
+    adjusted_gross_income: 100_000
+    us_govt_interest: 1_000
+    tax_unit_taxable_social_security: 1_000
+    la_state_employee_retirement_benefits: 1_000
+    la_state_teacher_retirement_benefits: 1_000
+    la_federal_retirement_benefits: 1_000
+    la_other_subtractions: 1_000
+    la_exemptions: 0
+    state_code: LA
+  output:
+    la_taxable_income: 94_000


### PR DESCRIPTION
- [x] `make format` and `make documentation` has been run. (You may also want to run `make test`.)

This PR fixes #65  

I added back in the `la_agi_subtractions` test and all the tests passed without any other changes on my local machine and on the GitHub actions.