### PR TITLE
fixing a bug in the va_tax_credit_for_low_income_individuals line 43

### DIFF
--- a/fiscalsim_us/variables/gov/states/va/tax/income/va_tax_credit_for_low_income_individuals.py
+++ b/fiscalsim_us/variables/gov/states/va/tax/income/va_tax_credit_for_low_income_individuals.py
@@ -40,4 +40,4 @@ class va_tax_credit_for_low_income_individuals(Variable):
         line_16 = where(line_15 > line_13, line_15, line_13)
         line_17 = where(net_tax > line_16, line_16, 0)
 
-        return line_17
+        return where(total_agi < threshold, line_17, 0)


### PR DESCRIPTION
@rickecon 


There was an error in the code that biased the credit in my analysis, but I found it. It's just one line that only allows the credit if they are under the threshold. Here is my fix. 