### PR TITLE
Limit policyengine-core dependency in setup.py

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,10 +22,11 @@ jobs:
       - name: Run tests
         run: make test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2024-04-10 16:00:00
+
+### Added
+
+- Limits the policyengine-core dependency in `setup.py` to be less than v. 2.9.
+
 ## [0.2.6] - 2023-11-14 17:00:00
 
 ### Added
@@ -191,6 +197,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First prototype version based off of openfisca-us and tax-calculator.
 
 
+[0.2.7]: https://github.com/TheCGO/fiscalsim-us/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/TheCGO/fiscalsim-us/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/TheCGO/fiscalsim-us/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/TheCGO/fiscalsim-us/compare/v0.2.3...v0.2.4

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -174,3 +174,8 @@
     added:
       - Updates Montana tax logic
   date: 2023-11-14 17:00:00
+- bump: patch
+  changes:
+    added:
+      - Limits the policyengine-core dependency in `setup.py` to be less than v. 2.9.
+  date: 2024-04-10 16:00:00

--- a/fiscalsim_us/__init__.py
+++ b/fiscalsim_us/__init__.py
@@ -7,6 +7,7 @@ contains simulation variables (source code) and legislation parameters (data).
 
 See https://openfisca.org/doc/key-concepts/tax_and_benefit_system.html
 """
+
 from fiscalsim_us.system import (
     CountryTaxBenefitSystem,
     Simulation,

--- a/fiscalsim_us/tools/taxcalc/generate_taxcalc_variable.py
+++ b/fiscalsim_us/tools/taxcalc/generate_taxcalc_variable.py
@@ -62,9 +62,11 @@ def create_taxcalc_alias(name: str, variable: Type[Variable]):
         dict(
             entity=TaxUnit,
             definition_period=YEAR,
-            label=variable.label + " (Tax-Calculator)"
-            if hasattr(variable, "label")
-            else name + "(Tax-Calculator)",
+            label=(
+                variable.label + " (Tax-Calculator)"
+                if hasattr(variable, "label")
+                else name + "(Tax-Calculator)"
+            ),
             unit=variable.unit if hasattr(variable, "unit") else None,
             documentation=documentation,
             value_type=variable.value_type,

--- a/fiscalsim_us/tools/taxsim/generate_taxsim_tests.py
+++ b/fiscalsim_us/tools/taxsim/generate_taxsim_tests.py
@@ -132,9 +132,11 @@ class TaxSim35:
         else:
             input_csv = pd.DataFrame(
                 {
-                    col: [value]
-                    if not isinstance(value, collections.Sequence)
-                    else value
+                    col: (
+                        [value]
+                        if not isinstance(value, collections.Sequence)
+                        else value
+                    )
                     for col, value in input_data.items()
                 }
             )

--- a/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/charitable_contribution/co_charitable_contribution_subtraction.py
+++ b/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/charitable_contribution/co_charitable_contribution_subtraction.py
@@ -10,7 +10,7 @@ class co_charitable_contribution_subtraction(Variable):
     reference = (
         "https://tax.colorado.gov/sites/tax/files/documents/DR0104AD_2022.pdf#page=1",
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=12",
-        "https://casetext.com/regulation/colorado-administrative-code/department-200-department-of-revenue/division-201-taxation-division/rule-1-ccr-201-2-income-tax/rule-39-22-1044m-charitable-contribution-subtraction-for-taxpayers-claiming-the-federal-standard-deduction"
+        "https://casetext.com/regulation/colorado-administrative-code/department-200-department-of-revenue/division-201-taxation-division/rule-1-ccr-201-2-income-tax/rule-39-22-1044m-charitable-contribution-subtraction-for-taxpayers-claiming-the-federal-standard-deduction",
         # C.R.S. 39-22-104(4)(m)(1)
     )
     defined_for = "co_charitable_contribution_subtraction_eligible"

--- a/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/charitable_contribution/co_charitable_contribution_subtraction_eligible.py
+++ b/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/charitable_contribution/co_charitable_contribution_subtraction_eligible.py
@@ -9,7 +9,7 @@ class co_charitable_contribution_subtraction_eligible(Variable):
     reference = (
         "https://tax.colorado.gov/sites/tax/files/documents/DR0104AD_2022.pdf#page=1",
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=12",
-        "https://casetext.com/regulation/colorado-administrative-code/department-200-department-of-revenue/division-201-taxation-division/rule-1-ccr-201-2-income-tax/rule-39-22-1044m-charitable-contribution-subtraction-for-taxpayers-claiming-the-federal-standard-deduction"
+        "https://casetext.com/regulation/colorado-administrative-code/department-200-department-of-revenue/division-201-taxation-division/rule-1-ccr-201-2-income-tax/rule-39-22-1044m-charitable-contribution-subtraction-for-taxpayers-claiming-the-federal-standard-deduction",
         # C.R.S. 39-22-104(4)(m)(1)
     )
     defined_for = StateCode.CO

--- a/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/collegeinvest_contribution/co_collegeinvest_subtraction.py
+++ b/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/collegeinvest_contribution/co_collegeinvest_subtraction.py
@@ -10,7 +10,7 @@ class co_collegeinvest_subtraction(Variable):
     reference = (
         "https://tax.colorado.gov/sites/tax/files/documents/DR0104AD_2022.pdf#page=1",
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=12",
-        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/"
+        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/",
         # C.R.S. 39-22-104(4)(i)(II)(B)
     )
     defined_for = StateCode.CO

--- a/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/military_retirement/co_military_retirement_subtraction.py
+++ b/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/military_retirement/co_military_retirement_subtraction.py
@@ -10,7 +10,7 @@ class co_military_retirement_subtraction(Variable):
     reference = (
         "https://tax.colorado.gov/sites/tax/files/documents/DR0104AD_2022.pdf#page=1",
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=12",
-        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/"
+        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/",
         # C.R.S. 39-22-104(4)(y)(I)
     )
     definition_period = YEAR

--- a/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/pension/co_pension_subtraction_indv.py
+++ b/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/pension/co_pension_subtraction_indv.py
@@ -10,7 +10,7 @@ class co_pension_subtraction_indv(Variable):
     reference = (
         "https://tax.colorado.gov/sites/tax/files/documents/DR0104AD_2022.pdf#page=1",
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=12",
-        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/"
+        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/",
         # C.R.S. 39-22-104(4)(g)(III)
     )
     definition_period = YEAR

--- a/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/pension/co_pension_subtraction_indv_eligible..py
+++ b/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/pension/co_pension_subtraction_indv_eligible..py
@@ -9,7 +9,7 @@ class co_pension_subtraction_indv_eligible(Variable):
     reference = (
         "https://tax.colorado.gov/sites/tax/files/documents/DR0104AD_2022.pdf#page=1",
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=12",
-        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/"
+        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/",
         # C.R.S. 39-22-104(4)(g)(III)
     )
     definition_period = YEAR

--- a/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/pension/co_social_security_subtraction_indv.py
+++ b/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/pension/co_social_security_subtraction_indv.py
@@ -10,7 +10,7 @@ class co_social_security_subtraction_indv(Variable):
     reference = (
         "https://tax.colorado.gov/sites/tax/files/documents/DR0104AD_2022.pdf#page=1",
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=12",
-        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/"
+        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/",
         # C.R.S. 39-22-104(4)(g)(III)
     )
     definition_period = YEAR

--- a/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/pension/co_social_security_subtraction_indv_eligible.py
+++ b/fiscalsim_us/variables/gov/states/co/tax/income/subtractions/pension/co_social_security_subtraction_indv_eligible.py
@@ -10,7 +10,7 @@ class co_social_security_subtraction_indv_eligible(Variable):
     reference = (
         "https://tax.colorado.gov/sites/tax/files/documents/DR0104AD_2022.pdf#page=1",
         "https://tax.colorado.gov/sites/tax/files/documents/DR_104_Book_2022.pdf#page=12",
-        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/"
+        "https://law.justia.com/codes/colorado/2022/title-39/article-22/part-1/section-39-22-104/",
         # C.R.S. 39-22-104(4)(g)(III)
     )
     definition_period = YEAR

--- a/fiscalsim_us/variables/gov/states/md/tax/income/credits/poverty_line/is_eligible_md_poverty_line_credit.py
+++ b/fiscalsim_us/variables/gov/states/md/tax/income/credits/poverty_line/is_eligible_md_poverty_line_credit.py
@@ -31,7 +31,7 @@ class is_eligible_md_poverty_line_credit(Variable):
         earnings_below_fpg = earnings <= fpg
         # (iii)    who is not claimed as an exemption on another individual’s
         #  tax return under § 10–211 of this title;
-        # SKIP - assumed throughout PolicyEngine-us.
+        # SKIP - assumed throughout FiscalSim-US.
         # (iv)    for whom the credit allowed under § 10–704(a)(1) of this
         # subtitle is less than the State income tax.
         # This appears to refer to the MD total EITC per

--- a/fiscalsim_us/variables/gov/states/sc/tax/income/deductions/net_capital_gain/sc_net_capital_gain_deduction.py
+++ b/fiscalsim_us/variables/gov/states/sc/tax/income/deductions/net_capital_gain/sc_net_capital_gain_deduction.py
@@ -10,7 +10,7 @@ class sc_net_capital_gain_deduction(Variable):
     defined_for = StateCode.SC
     reference = (
         "https://dor.sc.gov/forms-site/Forms/IITPacket_2021.pdf#page=15",
-        "https://www.scstatehouse.gov/code/t12c006.php"
+        "https://www.scstatehouse.gov/code/t12c006.php",
         # South Carolina Code of Laws Section 12-6-1150 (A)
     )
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="fiscalsim-us",
-    version="0.2.6",
+    version="0.2.7",
     author="Center for Growth and Opportunity at Utah State University (CGO)",
     author_email="fiscalsim@thecgo.org",
     long_description=readme,
@@ -38,7 +38,7 @@ setup(
         "numpy>=1.24, <1.25",
         "pandas",
         "pathlib",
-        "policyengine-core>=2.8,<3",
+        "policyengine-core>=2.8,<2.9",
         "pytest",
         "pytest-dependency",
         "pyyaml",


### PR DESCRIPTION
- [x] `make format` and `make documentation` has been run. (You may also want to run `make test`.)

This PR:
- Limits the `policyengine-core` dependency in `setup.py` to be less than v. 2.9.