### PR TITLE
removing missing var

### DIFF
--- a/fiscalsim_us/variables/gov/states/mn/tax/income/mn_taxable_income.py
+++ b/fiscalsim_us/variables/gov/states/mn/tax/income/mn_taxable_income.py
@@ -25,6 +25,7 @@ class mn_taxable_income(Variable):
         ADDS = ["adjusted_gross_income", "mn_additions"]
         SUBTRACTS = [
             "mn_subtractions",
+            "mn_prev_year_state_refund",
             "mn_exemptions",
             "mn_deductions",
         ]

--- a/fiscalsim_us/variables/gov/states/mn/tax/income/mn_taxable_income.py
+++ b/fiscalsim_us/variables/gov/states/mn/tax/income/mn_taxable_income.py
@@ -25,7 +25,6 @@ class mn_taxable_income(Variable):
         ADDS = ["adjusted_gross_income", "mn_additions"]
         SUBTRACTS = [
             "mn_subtractions",
-            "mn_prev_year_state_refund",
             "mn_exemptions",
             "mn_deductions",
         ]

--- a/fiscalsim_us/variables/gov/states/mn/tax/income/subtractions/mn_prev_year_state_refund.py
+++ b/fiscalsim_us/variables/gov/states/mn/tax/income/subtractions/mn_prev_year_state_refund.py
@@ -1,7 +1,7 @@
 from fiscalsim_us.model_api import *
 
 
-class mmn_prev_year_state_refund(Variable):
+class mn_prev_year_state_refund(Variable):
     """
     Line 6 of Minnesota 2023 Individual Income Tax return from M1. This is the
     State income refund from a previous year that was reported in line 1 of


### PR DESCRIPTION
Fix error with `mn_prev_year_state_refund` on line 28 of `fiscalsim_us/variables/gov/states/mn/tax/income/mn_taxable_income.py`. @rickecon 