### PR TITLE
Update the version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.7] - 2024-12-19 16:30:00
+
+### Added
+
+- Fixes typo in `mn_prev_year_state_refund.py`
+
 ## [0.3.6] - 2024-11-22 01:15:00
 
 ### Added
@@ -257,6 +263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First prototype version based off of openfisca-us and tax-calculator.
 
 
+[0.3.7]: https://github.com/TheCGO/fiscalsim-us/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/TheCGO/fiscalsim-us/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/TheCGO/fiscalsim-us/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/TheCGO/fiscalsim-us/compare/v0.3.3...v0.3.4

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -229,3 +229,8 @@
     added:
       - Updates Minnesota tax logic to 2023 law
   date: 2024-11-22 01:15:00
+- bump: patch
+  changes:
+    added:
+      - Fixes typo in `mn_prev_year_state_refund.py`
+  date: 2024-12-19 16:30:00

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="fiscalsim-us",
-    version="0.3.6",
+    version="0.3.7",
     author="Richard W. Evans",
     author_email="rick@abundance.institute",
     long_description=readme,


### PR DESCRIPTION
- [x] `make format` and `make documentation` has been run. (You may also want to run `make test`.)

This PR updates the version of FiscalSim-US to account for changes in the last PR ([PR #89](https://github.com/TheCGO/fiscalsim-us/pull/89)) that fix a typo in a MN variable.